### PR TITLE
Mainly fixes and changes required to work with "Great Expectations" tool. Version 1.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -5,3 +5,4 @@
 - Alias `dialect` for `DremioDialect_pyodbc` created
 - Expose supported data types to pyodbc level, so that it works with "Great Expectations"
 - Introduced `?filter_schema_names=Space1.Folder1,Space2.Folder2` parameter to filter schemas. If the parameter is not set, all schemas will be returned
+- Added has_table implementation for dialect, which seems to be required by latest Apache Superset

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,7 @@
+## Release 1.2.0.
+
+- Replace parameterized statements by fully compiled, because Dremio does not support parameterized statements.
+- Bugfix in get_columns, when Schema is None, the schema "None" was prefixed
+- Alias `dialect` for `DremioDialect_pyodbc` created
+- Expose supported data types to pyodbc level, so that it works with "Great Expectations"
+- Introduced `?filter_schema_names=Space1.Folder1,Space2.Folder2` parameter to filter schemas. If the parameter is not set, all schemas will be returned

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ test_requirements = [
 
 setup(
     name='sqlalchemy_dremio',
-    version='1.1.6',
+    version='1.2.0',
     description="A SQLAlchemy dialect for Dremio via the ODBC and Flight interface.",
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/sqlalchemy_dremio/__init__.py
+++ b/sqlalchemy_dremio/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.1.6'
+__version__ = '1.2.0'
 
 from .db import Connection, connect
 from sqlalchemy.dialects import registry

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -213,6 +213,16 @@ class DremioDialect(default.DefaultDialect):
         schema_names = [r[0] for r in result]
         return schema_names
 
+    @reflection.cache
+    def has_table(self, connection, table_name, schema=None, **kw):
+        sql = 'SELECT COUNT(*) FROM INFORMATION_SCHEMA."TABLES"'
+        sql += " WHERE TABLE_NAME = '" + str(table_name) + "'"
+        if schema is not None and schema != "":
+            sql += " AND TABLE_SCHEMA = '" + str(schema) + "'"
+        result = connection.execute(sql)
+        countRows = [r[0] for r in result]
+        return countRows[0] > 0
+
     def get_view_names(self, connection, schema=None, **kwargs):
         return []
 

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -148,6 +148,7 @@ class DremioDialect(default.DefaultDialect):
     preparer = DremioIdentifierPreparer
     execution_ctx_cls = DremioExecutionContext
     default_paramstyle = "qmark"
+    filter_schema_names = []
 
     @classmethod
     def dbapi(cls):
@@ -205,13 +206,8 @@ class DremioDialect(default.DefaultDialect):
         return table_names
 
     def get_schema_names(self, connection, schema=None, **kw):
-        database = connection.engine.url.database
-        if database != None and ';' in database:
-            database = database.split(';')[0]
-        # This is only returning the database from connection string.
-        # If you want to get all databases, don't pass a database name.
-        if database != None and database != "":
-            return [database]
+        if len(self.filter_schema_names) > 0:
+            return self.filter_schema_names
 
         result = connection.execute("SHOW SCHEMAS")
         schema_names = [r[0] for r in result]

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -147,6 +147,7 @@ class DremioDialect(default.DefaultDialect):
     ddl_compiler = DremioDDLCompiler
     preparer = DremioIdentifierPreparer
     execution_ctx_cls = DremioExecutionContext
+    default_paramstyle = "qmark"
 
     @classmethod
     def dbapi(cls):
@@ -173,10 +174,10 @@ class DremioDialect(default.DefaultDialect):
         return []
 
     def get_columns(self, connection, table_name, schema, **kw):
-        q = "DESCRIBE \"{1}\"".format(schema, table_name)
+        sql = "DESCRIBE \"{0}\"".format(table_name)
         if schema != None and schema != "":
-            q = "DESCRIBE \"{0}\".\"{1}\"".format(schema, table_name)
-        cursor = connection.execute(q)
+            sql = "DESCRIBE \"{0}\".\"{1}\"".format(schema, table_name)
+        cursor = connection.execute(sql)
         result = []
         for col in cursor:
             cname = col[0]
@@ -204,9 +205,32 @@ class DremioDialect(default.DefaultDialect):
         return table_names
 
     def get_schema_names(self, connection, schema=None, **kw):
+        database = connection.engine.url.database
+        if database != None and ';' in database:
+            database = database.split(';')[0]
+        # This is only returning the database from connection string.
+        # If you want to get all databases, don't pass a database name.
+        if database != None and database != "":
+            return [database]
+
         result = connection.execute("SHOW SCHEMAS")
         schema_names = [r[0] for r in result]
         return schema_names
 
     def get_view_names(self, connection, schema=None, **kwargs):
         return []
+
+    # Workaround since Dremio does not support parameterized stmts
+    # Old queries should not have used queries with parameters, since Dremio does not support it
+    # and these queries failed. If there is no parameter, everything should work as before.
+    def do_execute(self, cursor, statement, parameters, context):
+        replaced_stmt = statement
+        for v in parameters:
+            if isinstance(v, (int, float)):
+                replaced_stmt = replaced_stmt.replace('?', str(v), 1)
+            else:
+                replaced_stmt = replaced_stmt.replace('?', "'" + str(v) + "'", 1)
+
+        super(DremioDialect, self).do_execute_no_params(
+            cursor, replaced_stmt, context
+        )

--- a/sqlalchemy_dremio/flight.py
+++ b/sqlalchemy_dremio/flight.py
@@ -48,7 +48,7 @@ class DremioCompiler(compiler.SQLCompiler):
     def visit_table(self, table, asfrom=False, **kwargs):
 
         if asfrom:
-            if table.schema != "":
+            if table.schema != None and table.schema != "":
                 fixed_schema = ".".join(["\"" + i.replace('"', '') + "\"" for i in table.schema.split(".")])
                 fixed_table = fixed_schema + ".\"" + table.name.replace("\"", "") + "\""
             else:
@@ -188,8 +188,10 @@ class DremioDialect_flight(default.DefaultDialect):
         return []
 
     def get_columns(self, connection, table_name, schema, **kw):
-        q = "DESCRIBE \"{0}\".\"{1}\"".format(schema, table_name)
-        cursor = connection.execute(q)
+        sql = "DESCRIBE \"{0}\"".format(table_name)
+        if schema != None and schema != "":
+            sql = "DESCRIBE \"{0}\".\"{1}\"".format(schema, table_name)
+        cursor = connection.execute(sql)
         result = []
         for col in cursor:
             cname = col[0]

--- a/sqlalchemy_dremio/pyodbc.py
+++ b/sqlalchemy_dremio/pyodbc.py
@@ -22,14 +22,17 @@ class DremioDialect_pyodbc(PyODBCConnector, DremioDialect):
         opts = url.translate_connect_args(username='user')
 
         connect_args = {}
+        schemaName = opts['database'] if 'database' in opts else ""
         connectors = ["DRIVER={%s}" % self.pyodbc_driver_name,
                       "UID=%s" % opts['user'],
                       "PWD=%s" % opts['password'],
                       'HOST=%s' % opts['host'],
                       'PORT=%s' % opts['port'],
-                      'Schema=%s' % opts['database']
+                      'Schema=%s' % schemaName
                       ]
 
+        if 'filter_schema_names' in url.query:
+            self.filter_schema_names = url.query['filter_schema_names'].split(',')
         return [[";".join(connectors)], connect_args]
 
 

--- a/sqlalchemy_dremio/pyodbc.py
+++ b/sqlalchemy_dremio/pyodbc.py
@@ -2,8 +2,7 @@ import platform
 
 from sqlalchemy.connectors.pyodbc import PyODBCConnector
 
-from .base import DremioExecutionContext, DremioDialect
-
+from .base import DremioExecutionContext, DremioDialect, _type_map
 
 class DremioExecutionContext_pyodbc(DremioExecutionContext):
     pass
@@ -32,3 +31,8 @@ class DremioDialect_pyodbc(PyODBCConnector, DremioDialect):
                       ]
 
         return [[";".join(connectors)], connect_args]
+
+
+dialect = DremioDialect_pyodbc
+# some tools like "Great Expectations" use this to find the types on root level.
+locals().update(_type_map)

--- a/test/test_dremio.py
+++ b/test/test_dremio.py
@@ -42,3 +42,16 @@ def test_simple_sql():
 def test_row_count(engine):
     rows = conftest.get_engine().execute('SELECT * FROM $scratch.sqlalchemy_tests').fetchall()
     assert len(rows) is 2
+
+def test_has_table_True():
+    assert conftest.get_engine().has_table("version", schema = "sys")
+
+def test_has_table_True2():
+    assert conftest.get_engine().has_table("version")
+
+def test_has_table_False():
+    assert not conftest.get_engine().has_table("does_not_exist", schema = "sys")
+
+def test_has_table_False2():
+    assert not conftest.get_engine().has_table("does_not_exist")
+


### PR DESCRIPTION
- Replace parameterized statements by fully compiled, because Dremio does not support parameterized statements.
- Bugfix in get_columns, when Schema is None, the schema "None" was prefixed
- Alias `dialect` for `DremioDialect_pyodbc` created
- Expose supported data types to pyodbc level, so that it works with "Great Expectations"
- Introduced `?filter_schema_names=Space1.Folder1,Space2.Folder2` parameter to filter schemas. If the parameter is not set, all schemas will be returned
- Added release notes file
- Uplift to version 1.2.0