### PR TITLE
Added missing type mappings

### DIFF
--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -34,7 +34,8 @@ _type_map = {
     'ANY': types.VARCHAR,
     
     'ARRAY': types.ARRAY,
-    'ROW': types.JSON
+    'ROW': types.JSON,
+    'BINARY VARYING': types.LargeBinary,
 }
 
 

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -31,7 +31,10 @@ _type_map = {
     'VARCHAR': types.VARCHAR,
     'smallint': types.SMALLINT,
     'CHARACTER VARYING': types.VARCHAR,
-    'ANY': types.VARCHAR
+    'ANY': types.VARCHAR,
+    
+    'ARRAY': types.ARRAY,
+    'ROW': types.JSON
 }
 
 


### PR DESCRIPTION
I was trying to get Apache Superset to work with Dremio (20.1.0-202202061055110045-36733c65) and ran into problems with some of the column types Dremio seems to return. 

This PR fixes the ones I ran into - I am not sure this list is exhaustive.