### PR TITLE
Add the routing_engine property

### DIFF
--- a/sqlalchemy_dremio/db.py
+++ b/sqlalchemy_dremio/db.py
@@ -97,6 +97,7 @@ class Connection(object):
         add_header(properties, headers, 'routing_queue')
         add_header(properties, headers, 'routing_tag')
         add_header(properties, headers, 'quoting')
+        add_header(properties, headers, 'routing_engine')
 
         self.flightclient = client
         self.options = flight.FlightCallOptions(headers=headers)

--- a/sqlalchemy_dremio/flight.py
+++ b/sqlalchemy_dremio/flight.py
@@ -169,17 +169,21 @@ class DremioDialect_flight(default.DefaultDialect):
         if 'database' in opts:
             connectors.append('{0}={1}'.format('Schema', opts['database']))
 
-        def add_property(url, property_name, connectors):
-            if property_name in url.query:
-                connectors.append('{0}={1}'.format(property_name, url.query[property_name]))
+        # Clone the query dictionary with lower-case keys.
+        lc_query_dict = {k.lower(): v for k, v in url.query.items()}
+
+        def add_property(lc_query_dict, property_name, connectors):
+            if property_name.lower() in lc_query_dict:
+                connectors.append('{0}={1}'.format(property_name, lc_query_dict[property_name.lower()]))
         
-        add_property(url, 'UseEncryption', connectors)
-        add_property(url, 'DisableCertificateVerification', connectors)
-        add_property(url, 'TrustedCerts', connectors)
-        add_property(url, 'routing_queue', connectors)
-        add_property(url, 'routing_tag', connectors)
-        add_property(url, 'quoting', connectors)
-        add_property(url, 'token', connectors)
+        add_property(lc_query_dict, 'UseEncryption', connectors)
+        add_property(lc_query_dict, 'DisableCertificateVerification', connectors)
+        add_property(lc_query_dict, 'TrustedCerts', connectors)
+        add_property(lc_query_dict, 'routing_queue', connectors)
+        add_property(lc_query_dict, 'routing_tag', connectors)
+        add_property(lc_query_dict, 'quoting', connectors)
+        add_property(lc_query_dict, 'routing_engine', connectors)
+        add_property(lc_query_dict, 'Token', connectors)
 
         return [[";".join(connectors)], connect_args]
 

--- a/test.py
+++ b/test.py
@@ -2,7 +2,7 @@ from sqlalchemy import create_engine
 import time
 
 
-db_uri = "dremio+flight://dremio:dremio123@localhost:32010/dremio;UseEncryption=false"
+db_uri = "dremio+flight://dremio:dremio123@localhost:32010/dremio?UseEncryption=false"
 engine = create_engine(db_uri)
 sql = 'SELECT * FROM sys.options limit 5 -- SQL Alchemy Flight Test '
 


### PR DESCRIPTION
* Add routing_engine to the set of accepted properties.
* Make connection options case-insensitive for keys.
* Correct the example URI to use ? before query parameters instead of ;