### PR TITLE
Add driver name to dialects

### DIFF
--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -2,6 +2,8 @@ from sqlalchemy import schema, types, pool
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import compiler
 
+_dialect_name = "dremio"
+
 _type_map = {
     'boolean': types.BOOLEAN,
     'BOOLEAN': types.BOOLEAN,
@@ -145,7 +147,8 @@ class DremioIdentifierPreparer(compiler.IdentifierPreparer):
 
 
 class DremioDialect(default.DefaultDialect):
-    name = 'dremio'
+    name = _dialect_name
+    driver = _dialect_name
     supports_sane_rowcount = False
     supports_sane_multi_rowcount = False
     poolclass = pool.SingletonThreadPool

--- a/sqlalchemy_dremio/flight.py
+++ b/sqlalchemy_dremio/flight.py
@@ -4,6 +4,8 @@ from sqlalchemy import schema, types, pool
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import compiler
 
+_dialect_name = "dremio+flight"
+
 _type_map = {
     'boolean': types.BOOLEAN,
     'BOOLEAN': types.BOOLEAN,
@@ -146,7 +148,8 @@ class DremioExecutionContext_flight(DremioExecutionContext):
 
 class DremioDialect_flight(default.DefaultDialect):
 
-    name = 'dremio+flight'
+    name = _dialect_name
+    driver = _dialect_name
     supports_sane_rowcount = False
     supports_sane_multi_rowcount = False
     poolclass = pool.SingletonThreadPool


### PR DESCRIPTION
SQLAlchemy dialects should have a `driver`: https://docs.sqlalchemy.org/en/13/core/internals.html#sqlalchemy.engine.interfaces.Dialect

[`ipython-sql`](https://github.com/catherinedevlin/ipython-sql) requires this be set - so this PR enables compatibility between `sqlalchemy-dremio` and `ipython-sql`. Thanks for reviewing!