### PR TITLE
Add Docker based Dremio CI workflow

### DIFF
--- a/.github/workflows/dremio.yml
+++ b/.github/workflows/dremio.yml
@@ -1,0 +1,39 @@
+name: Dremio Integration Tests
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches: [ master ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      dremio:
+        image: dremio/dremio-oss:latest
+        ports:
+          - 9047:9047
+          - 31010:31010
+          - 32010:32010
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          pip install -r requirements_dev.txt
+      - name: Wait for Dremio
+        run: |
+          for i in {1..60}; do
+            curl -f http://localhost:9047/ || true
+            if [ $? -eq 0 ]; then break; fi
+            sleep 5
+          done
+      - name: Run tests
+        env:
+          DREMIO_CONNECTION_URL: dremio+flight://dremio:dremio123@localhost:32010/dremio?UseEncryption=false
+        run: |
+          pytest

--- a/README.md
+++ b/README.md
@@ -54,9 +54,23 @@ WLM:
 
 https://docs.dremio.com/software/advanced-administration/workload-management/#query-tagging--direct-routing-configuration
 
+
 routing_queue - (Optional) The queue in which queries should run
 routing_tag - (Optonal) Routing tag to use.
 routing_engine - (Optional) The engine in which the queries should run
+
+Testing
+-------
+
+You can run the integration tests with the Dremio community edition Docker image.
+
+```bash
+docker run -d -p 9047:9047 -p 31010:31010 -p 32010:32010 --name dremio dremio/dremio-oss:latest
+export DREMIO_CONNECTION_URL="dremio+flight://dremio:dremio123@localhost:32010/dremio?UseEncryption=false"
+pytest
+```
+
+The workflow in `.github/workflows/dremio.yml` demonstrates how to run these tests automatically on GitHub Actions.
 
 Superset Integration
 -------------


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that spins up Dremio Community Edition via Docker
- document how to run tests locally with the Docker container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68583516c59c8331ab612f4337ed0d03