### PR TITLE
Synchronize project version

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.6
+current_version = 3.0.4
 commit = True
 tag = True
 

--- a/sqlalchemy_dremio/__init__.py
+++ b/sqlalchemy_dremio/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.2'
+__version__ = '3.0.4'
 
 from .db import Connection, connect
 from sqlalchemy.dialects import registry


### PR DESCRIPTION
## Summary
- fix mismatched version across files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6858495a233c8331bc4780b385d813e3