### PR TITLE
Add additional tests and lint setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.ruff]
+line-length = 100
+exclude = ["scripts"]
+

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,3 +3,4 @@ SQLAlchemy~=2.0.41
 pyarrow~=20.0.0
 bump-my-version>=1.2.0
 pandas>=2.2
+ruff>=0.1

--- a/sqlalchemy_dremio/__init__.py
+++ b/sqlalchemy_dremio/__init__.py
@@ -1,6 +1,6 @@
 __version__ = '3.0.4'
 
-from .db import Connection, connect
+from .db import Connection as Connection, connect as connect
 from sqlalchemy.dialects import registry
 
 # Register the Flight end point

--- a/sqlalchemy_dremio/base.py
+++ b/sqlalchemy_dremio/base.py
@@ -52,7 +52,7 @@ class DremioCompiler(compiler.SQLCompiler):
     def visit_table(self, table, asfrom=False, **kwargs):
 
         if asfrom:
-            if table.schema != None and table.schema != "":
+            if table.schema is not None and table.schema != "":
                 fixed_schema = ".".join(["\"" + i.replace('"', '') + "\"" for i in table.schema.split(".")])
                 fixed_table = fixed_schema + ".\"" + table.name.replace("\"", "") + "\""
             else:
@@ -185,7 +185,7 @@ class DremioDialect(default.DefaultDialect):
 
     def get_columns(self, connection, table_name, schema, **kw):
         sql = "DESCRIBE \"{0}\"".format(table_name)
-        if schema != None and schema != "":
+        if schema is not None and schema != "":
             sql = "DESCRIBE \"{0}\".\"{1}\"".format(schema, table_name)
         cursor = connection.execute(sql)
         result = []

--- a/sqlalchemy_dremio/flight.py
+++ b/sqlalchemy_dremio/flight.py
@@ -1,5 +1,3 @@
-import re
-
 from sqlalchemy import schema, types, pool
 from sqlalchemy.engine import default, reflection
 from sqlalchemy.sql import compiler
@@ -50,7 +48,7 @@ class DremioCompiler(compiler.SQLCompiler):
     def visit_table(self, table, asfrom=False, **kwargs):
 
         if asfrom:
-            if table.schema != None and table.schema != "":
+            if table.schema is not None and table.schema != "":
                 fixed_schema = ".".join(["\"" + i.replace('"', '') + "\"" for i in table.schema.split(".")])
                 fixed_table = fixed_schema + ".\"" + table.name.replace("\"", "") + "\""
             else:
@@ -212,7 +210,7 @@ class DremioDialect_flight(default.DefaultDialect):
 
     def get_columns(self, connection, table_name, schema, **kw):
         sql = "DESCRIBE \"{0}\"".format(table_name)
-        if schema != None and schema != "":
+        if schema is not None and schema != "":
             sql = "DESCRIBE \"{0}\".\"{1}\"".format(schema, table_name)
         cursor = connection.execute(sql)
         result = []

--- a/test/test_flight_dialect.py
+++ b/test/test_flight_dialect.py
@@ -1,0 +1,35 @@
+import sqlalchemy.engine.url as url
+
+from sqlalchemy_dremio.flight import DremioDialect_flight
+
+
+def _connect_args(connect_url: str) -> list[str]:
+    dialect = DremioDialect_flight()
+    args, kwargs = dialect.create_connect_args(url.make_url(connect_url))
+    assert kwargs == {}
+    return args[0].split(";")
+
+
+def test_create_connect_args_basic():
+    connectors = _connect_args("dremio+flight://localhost:31010")
+    assert connectors == ["HOST=localhost", "PORT=31010"]
+
+
+def test_create_connect_args_with_user_and_db():
+    connectors = _connect_args(
+        "dremio+flight://user:pass@localhost:32010/dremio"
+    )
+    assert "UID=user" in connectors
+    assert "PWD=pass" in connectors
+    assert "Schema=dremio" in connectors
+    assert "HOST=localhost" in connectors
+    assert "PORT=32010" in connectors
+
+
+def test_create_connect_args_query_options_case_insensitive():
+    connectors = _connect_args(
+        "dremio+flight://localhost:12345/db?useencryption=false&routing_engine=myeng"
+    )
+    assert "UseEncryption=false" in connectors
+    assert "routing_engine=myeng" in connectors
+


### PR DESCRIPTION
## Summary
- add Ruff config for linting
- enable Ruff in dev dependencies
- clean up lint issues across the codebase
- add tests for `create_connect_args`

## Testing
- `ruff check .`
- `pytest test/test_flight_dialect.py -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68584c53cc0c83318b69968ffe547155