### PR TITLE
Add datetime64 mapping

### DIFF
--- a/sqlalchemy_dremio/query.py
+++ b/sqlalchemy_dremio/query.py
@@ -29,6 +29,7 @@ _type_map = {
     'time': types.TIME,
     'TIME': types.TIME,
     'datetime64[ns]': types.DATETIME,
+    'datetime64[ms]': types.DATETIME,
     'timestamp': types.TIMESTAMP,
     'TIMESTAMP': types.TIMESTAMP,
     'varchar': types.VARCHAR,


### PR DESCRIPTION
## Summary
- map `datetime64[ms]` columns to SQLAlchemy `DATETIME`
- lint with `ruff` and run `pytest`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68584e7f8bec8331bd20b2d1915a9e42