### PR TITLE
Handle parameters in executemany

### DIFF
--- a/sqlalchemy_dremio/db.py
+++ b/sqlalchemy_dremio/db.py
@@ -183,7 +183,15 @@ class Cursor(object):
         return self
 
     @check_closed
-    def executemany(self, query):
+    def executemany(self, query, seq_of_parameters=None):
+        """Compatibility wrapper for DBAPI executemany.
+
+        ``df.to_sql`` and other helpers expect the ``executemany`` method to
+        accept the SQL statement and a sequence of parameters.  Dremio does not
+        support parameterized execution, so this method simply raises a
+        ``NotSupportedError`` regardless of the parameters passed.
+        """
+
         raise NotSupportedError(
             '`executemany` is not supported, use `execute` instead')
 


### PR DESCRIPTION
## Summary
- fix `executemany` signature so pandas `to_sql` doesn't raise `TypeError`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858544425148331ad55e5fba989c080