### PR TITLE
Added dependencies markers for compatibility with Python 3.8.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,11 @@ The ODBC connection to superset is now deprecated. Please update sqlalchemy_drem
 Release Notes
 -------------
 
+3.0.5
+-----
+- Add dependency markers for compatibility with Python 3.8.
+- Addressing issue #44: Add support for type `datetime[ms]`.
+
 3.0.4
 -----
 - Addressing issue #34 and #37: Add driver name to dialects

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.4
+current_version = 3.0.5
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,9 @@ with open('README.md') as readme_file:
     readme = readme_file.read()
 
 requirements = [
-    'SQLAlchemy~=2.0.41',
-    'pyarrow~=20.0.0'
+    'sqlalchemy>=1.3.24',
+    "pyarrow>=18.0.0; python_version>='3.9'",
+    "pyarrow>=5.0.0; python_version<'3.9'",
 ]
 
 setup_requirements = [
@@ -21,7 +22,7 @@ test_requirements = [
 
 setup(
     name='sqlalchemy_dremio',
-    version='3.0.4',
+    version='3.0.5',
     description="A SQLAlchemy dialect for Dremio via the Flight interface.",
     long_description=readme,
     long_description_content_type='text/markdown',

--- a/sqlalchemy_dremio/__init__.py
+++ b/sqlalchemy_dremio/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '3.0.4'
+__version__ = '3.0.5'
 
 from .db import Connection as Connection, connect as connect
 from sqlalchemy.dialects import registry


### PR DESCRIPTION
Changes to requirements in setup.py to add compatibility with Python 3.8. This is needed so that the sqlalchemy_dremio can be used by other projects that are supporting Python 3.8.